### PR TITLE
Fix ugly scrollbars on firefox & other browsers

### DIFF
--- a/lib/components/Layout/Slider/slider.css
+++ b/lib/components/Layout/Slider/slider.css
@@ -12,7 +12,7 @@
 	width: 100%;
 	transition: all 0.8s;
 	transform: translateX(-200%);
-	overflow: scroll;
+	overflow: auto;
 	transform-style: preserve-3d;
 }
 

--- a/lib/components/Layout/Slider/styles.css
+++ b/lib/components/Layout/Slider/styles.css
@@ -38,7 +38,7 @@
 	background: #f5f5f5;
 	height: auto;
 	max-height: 240px;
-	overflow: scroll;
+	overflow: auto;
 }
 
 .interactive-module-wrapper .editor .hljs {

--- a/lib/styles/global.css
+++ b/lib/styles/global.css
@@ -52,7 +52,7 @@
 	min-width: var(--menu-width);
 	width: 100%;
 	height: calc(100% - 65px);
-	overflow: scroll;
+	overflow: auto;
 	opacity: 1;
 	position: absolute;
 }
@@ -118,7 +118,7 @@
 	width: var(--menu-width);
 	height: 100%;
 	padding: 0 1rem 0 0;
-	overflow: scroll;
+	overflow: auto;
 	top: 0;
 	left: calc(0px - var(--menu-width));
 	background: linear-gradient(0deg, rgba(0, 0, 0, 0.102), rgba(0, 0, 0, 0.102));

--- a/lib/styles/initial.css
+++ b/lib/styles/initial.css
@@ -111,10 +111,6 @@ textarea[type="text"]:focus {
 	outline: none;
 }
 
-::-webkit-scrollbar {
-	display: none;
-}
-
 ::-moz-placeholder {
 	color: #d8d7d7;
 }
@@ -131,6 +127,10 @@ textarea[type="text"]:focus {
 
 ::-webkit-scrollbar {
 	display: none;
+}
+
+* {
+	scrollbar-width: none;
 }
 
 input, textarea, select {


### PR DESCRIPTION
When viewed in firefox and maybe other non webkit browsers there are many extra, ugly scrollbars on the gundb docs. This PR makes 2 changes:
- change instances of overflow: scroll; to overflow: auto; to hide extra scrollbars especially on older browsers
- adds a firefox equivalent to ::-webkit-scrollbar {display: none;}

screenshot before change, firefox on left, chromium on right:
![2021-05-20T15:45:30:-05:00_1920x1080](https://user-images.githubusercontent.com/2590830/119053502-c31d4480-b98b-11eb-9924-61e3d6657f43.png)
