### PR TITLE
Use relative paths on homepage

### DIFF
--- a/lib/components/HomePage/template.html
+++ b/lib/components/HomePage/template.html
@@ -153,8 +153,8 @@
     <div class="center row focus crack">
       <p class="loud rgb">protecting people's privacy</p>
       <p class="rgb">the decentralized database for developers.</p>
-      <a href="https://gun.eco/docs/Todo-Dapp"><button class="rgb glitch">GET STARTED</button></a>
-      <a href="https://gun.eco/docs/API"><button class="rgb glitch">DOCUMENTATION</button></a>
+      <a href="/docs/Todo-Dapp"><button class="rgb glitch">GET STARTED</button></a>
+      <a href="/docs/API"><button class="rgb glitch">DOCUMENTATION</button></a>
     </div>
     <a href="https://gitter.im/amark/gun" class="left gap fade" style="position: absolute; bottom: 0; left: 0;"><img src="https://gun.eco/media/gitter.svg" class="icon rgb glitch"></a>
     <a href="https://twitter.com/marknadal" class="right gap fade" style="position: absolute; bottom: 0; right: 0;"><img src="https://gun.eco/media/twitter.png" class="icon rgb glitch"></a>
@@ -237,7 +237,7 @@
         allowfullscreen
       ></div>
       <div class="unit">
-        <p class="left just">&emsp;GUN gives you the most powerful digital weapons on the internet: <a href="https://gun.eco/docs/Cartoon-Cryptography" class="ru">encryption</a> for privacy, and independence through <a href="https://gun.eco/distributed/matters.html" class="gu">decentralization</a>. There are now enough phones on the planet to power all of Facebook by the people, for the people, and of the people. So why don't we?
+        <p class="left just">&emsp;GUN gives you the most powerful digital weapons on the internet: <a href="/docs/Cartoon-Cryptography" class="ru">encryption</a> for privacy, and independence through <a href="/distributed/matters.html" class="gu">decentralization</a>. There are now enough phones on the planet to power all of Facebook by the people, for the people, and of the people. So why don't we?
       </div>
     </div>
   
@@ -415,11 +415,11 @@
       <style>.wow .col { padding: 1em; }</style>
       <div class="col unit left">
         <p class="shout crack above rgb glitch" style="max-width: 6em;"><b>Build apps you love</b></p>
-        <p class="justify">GUN is an ecosystem of modular tools. Graphs take you beyond just <a href="https://gun.eco/docs/Content-Addressing" class="ru">immutable hashes</a>, they let you do <a href="https://github.com/amark/gun" class="gu">realtime multiplayer</a> updates on any type of data. <a href="https://gun.eco/docs/SEA" class="bu">SEA</a> gives you the best local-first secure user accounts, but with normal logins and even p2p password resets using <a href="https://twitter.com/marknadal/status/1427715775838572545" class="ru">3FA</a>!</p>
+        <p class="justify">GUN is an ecosystem of modular tools. Graphs take you beyond just <a href="/docs/Content-Addressing" class="ru">immutable hashes</a>, they let you do <a href="https://github.com/amark/gun" class="gu">realtime multiplayer</a> updates on any type of data. <a href="/docs/SEA" class="bu">SEA</a> gives you the best local-first secure user accounts, but with normal logins and even p2p password resets using <a href="https://twitter.com/marknadal/status/1427715775838572545" class="ru">3FA</a>!</p>
       </div>
       <div class="col unit left">
         <p class="shout crack above rgb glitch" style="max-width: 6em;"><b>70%+ cost savings</b></p>
-        <p class="justify"><a href="https://gun.eco/docs/AXE" class="ru">AXE</a> will let you deploy without clouds to a decentralized edge CDN for your JAMstack apps. It runs everywhere, even via browsers with WebRTC, using the simple yet powerful <a href="https://gun.eco/distributed/matters.html" class="gu">HAM</a> "CRDT" conflict resolution algorithm. Meanwhile, <a href="https://gun.eco/docs/DAM" class="bu">DAM</a> let's you do offline mesh networking and <a href="https://gun.eco/docs/RAD" class="ru">RAD</a> stores your data.</p>
+        <p class="justify"><a href="/docs/AXE" class="ru">AXE</a> will let you deploy without clouds to a decentralized edge CDN for your JAMstack apps. It runs everywhere, even via browsers with WebRTC, using the simple yet powerful <a href="/distributed/matters.html" class="gu">HAM</a> "CRDT" conflict resolution algorithm. Meanwhile, <a href="/docs/DAM" class="bu">DAM</a> let's you do offline mesh networking and <a href="/docs/RAD" class="ru">RAD</a> stores your data.</p>
       </div>
     </div>
   


### PR DESCRIPTION
(continuation of #23 from a different branch. just makes it easier for me to contribute multiple changes at once)

---

This PR simply changes the `href` attributes of the anchor links on the homepage to point to the local website instead of gun.eco. This will improve the experience of running a local development server. But more importantly, this will stop the `href` attribute value from triggering the `if` condition in `lib/components/Layout/index.js:168` which needlessly opens new tabs.

This is the first of a number of contributions I plan to make which will hopefully smooth out the experience newcomers have of reading the GUN documentation. It's inspired in part by amark/gun#1220. I think the way the criticism in that issue was levied was unprofessional and lacked any serious call to action, serving more to castigate the maintainers than improve the project. In that sense, I think Mark's response to it was understandable. But I think it would be unwise to discard the negative feelings some developers have towards the state of the documentation. I'd like to take hold of that discontent to push this project in a positive direction!