### PR TITLE
Improve document tree experience

### DIFF
--- a/lib/components/Menu/EventHandler.js
+++ b/lib/components/Menu/EventHandler.js
@@ -1,16 +1,15 @@
 async function EventHandler () {
-  const links = document.querySelectorAll('#menu li>a')
+  const items = document.querySelectorAll('#menu li')
 
-  links.forEach(link => {
-    link.onclick = async e => {
+  items.forEach(item => {
+    item.onclick = async e => {
       e.preventDefault()
+      e.stopPropagation()
 
-      link.parentNode.classList.toggle('open')
+      item.classList.toggle('open')
 
-      links.forEach(link => link.classList.remove('active'))
-      link.classList.add('active')
-
-      const item = e.target.parentNode
+      items.forEach(link => link.classList.remove('active'))
+      item.classList.add('active')
       let url
 
       if (item.getElementsByTagName('ul').length >= 1) {

--- a/lib/components/Menu/index.js
+++ b/lib/components/Menu/index.js
@@ -11,6 +11,7 @@ function createNode (items, parent) {
     a.href = Object.entries(item)[0][1]
     li.appendChild(a)
     if (item.pages) {
+      li.classList.add('sublist');
       createNode(Object.entries(item)[1][1], li)
     }
     ul.appendChild(li)

--- a/lib/components/Menu/index.js
+++ b/lib/components/Menu/index.js
@@ -67,12 +67,13 @@ async function Menu (UI) {
     // expand found items
     getParents(url, '#menu').forEach(link => link.classList.add('open'))
 
+    const item = url.parentNode
     // highlight first item
-    url.classList.add('active')
+    item.classList.add('active')
 
     // expand first item
-    if (url.parentNode.querySelector('ul')) {
-      url.parentNode.querySelector('ul').classList.add('open')
+    if (item.querySelector('ul')) {
+      item.querySelector('ul').classList.add('open')
     }
   }
 }

--- a/lib/components/Menu/index.js
+++ b/lib/components/Menu/index.js
@@ -11,7 +11,7 @@ function createNode (items, parent) {
     a.href = Object.entries(item)[0][1]
     li.appendChild(a)
     if (item.pages) {
-      li.classList.add('sublist');
+      li.classList.add('sublist')
       createNode(Object.entries(item)[1][1], li)
     }
     ul.appendChild(li)

--- a/lib/components/Menu/styles.css
+++ b/lib/components/Menu/styles.css
@@ -46,7 +46,7 @@
 	position: relative;
 }
 
-.menu ul li .active {
+.menu ul li.active>a {
 	color: var(--highlight-color) !important;
 }
 
@@ -65,9 +65,11 @@
 
 .menu ul .sublist.open::after {
 	transform: rotate(90deg);
-	/* color: var(--highlight-color); */
 }
 
+.menu ul .sublist.active::after {
+	color: var(--highlight-color);
+}
 
 .menu>ul>li>a {
 	padding: 1rem 0;

--- a/lib/components/Menu/styles.css
+++ b/lib/components/Menu/styles.css
@@ -42,6 +42,10 @@
 	display: block !important;
 }
 
+.menu ul li {
+	position: relative;
+}
+
 .menu ul li .active {
 	color: var(--highlight-color) !important;
 }
@@ -50,20 +54,20 @@
 	filter: brightness(1.2);
 }
 
-.menu ul ul::after {
+.menu ul li .sublist::after {
 	content: "\25b6";
 	position: absolute;
-	top: -1rem;
+	top: 0.25rem;
 	right: 0;
 	font-size: 0.8rem;
 	transition: all 0.5s;
-	transform: rotate(90deg);
-	color: var(--highlight-color);
 }
 
-.menu ul .open~.menu ul ul::after {
-	transform: rotate(9deg);
+.menu ul .sublist.open::after {
+	transform: rotate(90deg);
+	/* color: var(--highlight-color); */
 }
+
 
 .menu>ul>li>a {
 	padding: 1rem 0;

--- a/lib/components/Search/index.js
+++ b/lib/components/Search/index.js
@@ -21,17 +21,18 @@ function Search () {
 
     document.querySelectorAll('#menu ul').forEach(link => link.classList.remove('open'))
     document.querySelectorAll('#menu ul ul li>a').forEach(el => {
+      const item = el.parentNode;
       const name = el.textContent
       if (input.value !== '' && name.toUpperCase().includes(filter)) {
         searchItems.push(el)
         setTimeout(() => {
-          el.classList.add('active')
-          if (el.parentNode.querySelector('ul')) {
-            el.parentNode.querySelector('ul').classList.add('open')
+          item.classList.add('active')
+          if (item.querySelector('ul')) {
+            item.querySelector('ul').classList.add('open')
           }
         }, 100)
 
-        getParents(el.parentNode, '#menu ul').forEach(link => {
+        getParents(item, '#menu ul').forEach(link => {
           link.classList.add('open')
         })
       }

--- a/lib/components/Search/index.js
+++ b/lib/components/Search/index.js
@@ -21,7 +21,7 @@ function Search () {
 
     document.querySelectorAll('#menu ul').forEach(link => link.classList.remove('open'))
     document.querySelectorAll('#menu ul ul li>a').forEach(el => {
-      const item = el.parentNode;
+      const item = el.parentNode
       const name = el.textContent
       if (input.value !== '' && name.toUpperCase().includes(filter)) {
         searchItems.push(el)


### PR DESCRIPTION
Browsing the documentation on the website can at times feel like you're delving into a jungle of unknown size. This PR improves the document tree menu, giving the user more information about which pages have subordinate pages, and generally making it a little bit prettier.

| Before: | After: |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/101444034/158125232-7c0cee7a-4c83-48c9-ac5e-7a86a48f63d7.png) | ![image](https://user-images.githubusercontent.com/101444034/158125256-757c0b76-cd4a-4d08-8f01-9ea4d2ca8925.png) |

